### PR TITLE
컴포저의 3컬럼 레이아웃 구현 방식을 변경합니다. (V2-2458)

### DIFF
--- a/src/views/composer.vue
+++ b/src/views/composer.vue
@@ -41,20 +41,25 @@
               <editor v-show="currentLayer" :layer="currentLayer" ref="editor" />
             </div>
           </div>
-          <button
-            type="button"
-            class="fc-aside__btn"
-            @click="onToggleAside('left')">
-            <i class="material-icons">&#xE3E8;</i>
-          </button>
         </div>
+        <button
+          type="button"
+          class="fc-composer__content__btn fc-composer__content__btn--left"
+          @click="onToggleAside('left')">
+          <i class="material-icons">&#xE3E8;</i>
+        </button>
         <!--preview-->
         <preview
           :blocks="layers"
           :currentLayerIndex.sync="currentLayerIndex"
           ref="preview"
         />
-
+        <button
+          type="button"
+          class="fc-composer__content__btn fc-composer__content__btn--right"
+          @click="onToggleAside('right')">
+          <i class="material-icons">&#xE3E8;</i>
+        </button>
         <!--layers-->
         <div class="fc-aside fc-aside--right">
           <div class="fc-aside__content">
@@ -82,12 +87,7 @@
             </div>
           </div>
 
-          <button
-            type="button"
-            class="fc-aside__btn"
-            @click="onToggleAside('right')">
-            <i class="material-icons">&#xE3E8;</i>
-          </button>
+
         </div>
       </div>
       <layouts
@@ -477,22 +477,22 @@
           this.onUpdateCurrentLayerIndex(0);
           this.syncParamsAll();
         }
-      },      
-      syncParamsAll(){        
-        this.layers.forEach( layer => {        
+      },
+      syncParamsAll(){
+        this.layers.forEach( layer => {
           layer.values = this.getSyncedParams(layer);
         });
       },
-      getSyncedParams(layer) {    
+      getSyncedParams(layer) {
         const {params, values} = layer.layout;
         let resultValues = cloneDeep( layer.values );
         if (params) {
-          params.forEach( param => {          
-            const {name} = param;                     
-            if( resultValues[name] === undefined) { 
-              resultValues[name] = values[name]; 
+          params.forEach( param => {
+            const {name} = param;
+            if( resultValues[name] === undefined) {
+              resultValues[name] = values[name];
             }
-          })          
+          })
         }
         return resultValues;
       },
@@ -650,32 +650,58 @@
       padding-right: 0;
     }
 
-    &--aside-l {
-      padding-left: $sidebar-size + 14rem;
-    }
-
-    &--aside-r {
-      padding-right: $sidebar-size;
-    }
-
     &--portrait {
       width: percentage(1);
       max-width: $w-mobile;
       padding-right: 0;
     }
 
+    &--aside-l {
+      .fc-composer__content__btn--left {
+        left: $sidebar-size + 14rem;
+      }
+    }
+    &--aside-r {
+      .fc-composer__content__btn--right {
+        right: $sidebar-size;
+      }
+    }
+
     &__content {
-      overflow: scroll;
+      display: flex;
+      justify-content: space-between;
       position: relative;
-      flex: 1;
-      margin-left: 1.8rem;
-      margin-right: 1.8rem;
-      background: -moz-linear-gradient(top,  rgba(135,224,253,1) 0%, rgba(83,203,241,1) 40%, rgba(5,171,224,1) 100%);
-      background: -webkit-linear-gradient(top,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
-      background: linear-gradient(to bottom,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
-      box-shadow: 0 .3rem 1rem rgba($black, 0.24), 0 .3rem 1rem rgba($black,
-        0.16);
+      width: 100%;
+
       @include transition(null, 0.3s);
+
+      .fc-preview {
+        width: 100%;
+        margin: 0 1.8rem;
+      }
+
+      &__btn {
+        position: absolute;
+        top: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.8rem 0 1.8rem 0.6rem;
+        background-color: $secondary;
+        border-top-left-radius: 0.5rem;
+        border-bottom-left-radius: 0.5rem;
+        color: $white;
+        transform: translateY(-50%);
+
+        &--left {
+          left: 0;
+          transform: translateY(-50%) rotate(180deg);
+        }
+
+        &--right {
+          right: 0;
+        }
+      }
     }
   }
   .fc-guide {
@@ -715,19 +741,14 @@
   }
 
   .fc-aside {
-    display: flex;
-    position: fixed;
-    top: 0;
-    bottom: 0;
+    display: none;
+    position: relative;
     z-index: 10;
     box-sizing: border-box;
-    padding-top: $header-size;
     padding-bottom: 2rem;
     width: percentage(1);
     max-width: $sidebar-size;
     color: $white;
-    transform: translate3d(100%, 0, 0);
-    @include transition(null, 0.3s);
 
     &__content {
       width: 100%;
@@ -744,29 +765,12 @@
       background-color: $secondary;
     }
 
-    &__btn {
-      position: absolute;
-      top: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 1.8rem 0 1.8rem 0.6rem;
-      background-color: $secondary;
-      border-top-left-radius: 0.5rem;
-      border-bottom-left-radius: 0.5rem;
-      color: $white;
-      transform: translate3d(-100%, -50%, 0);
-    }
+
 
     &--right {
-      right: 0;
+      margin-left: 1.8rem;
       .fc-composer--aside-r & {
-        transform: translate3d(0, 0, 0);
-      }
-      .fc-aside {
-        &__btn {
-          left: 0;
-        }
+        display: flex;
       }
       .btn {
         color: $white;
@@ -774,18 +778,14 @@
 
     }
     &--left {
-      left: 0;
+      margin-right: 1.8rem;
       max-width: $sidebar-size + 14rem;
-      transform: translate3d(-100%, 0, 0);
 
       .fc-composer--aside-l & {
-        transform: translate3d(0, 0, 0);
-      }
-
-      .fc-aside__btn {
-        right: 0;
-        transform: translate3d(100%, -50%, 0) rotate(180deg);
+        display: flex;
       }
     }
   }
+
+
 </style>

--- a/src/views/preview/preview.vue
+++ b/src/views/preview/preview.vue
@@ -85,7 +85,7 @@
   @import '../../assets/scss/utils/utilities';
 
   .fc-preview {
-    overflow: scroll;
+    overflow: auto;
     background-color: $white;
 
     &__save {

--- a/src/views/preview/preview.vue
+++ b/src/views/preview/preview.vue
@@ -85,6 +85,7 @@
   @import '../../assets/scss/utils/utilities';
 
   .fc-preview {
+    overflow: scroll;
     background-color: $white;
 
     &__save {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 리디자인

## 관련된 이슈를 이야기해주세요.
V2-2458

## 코드의 실행결과를 볼 수 있는 스크린샷이 있을까요?
전
<img width="2421" alt="스크린샷 2021-03-25 오후 4 28 08" src="https://user-images.githubusercontent.com/57934965/112445318-57a36600-8d92-11eb-8bb7-171f0e35f55d.png">

후
<img width="2420" alt="스크린샷 2021-03-25 오후 4 28 18" src="https://user-images.githubusercontent.com/57934965/112445326-5a05c000-8d92-11eb-9b29-ed435f613eeb.png">

## 무엇이 변경되었나요?
- 3컬럼 레이아웃 구현 방식을 변경합니다.
- position: fixed를 통해 sidebar의 위치를 조절하던 부분을 상위 컨테이너에 flex를 주어 처리하도록 합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
1. 우측 레이아웃 리스트의 drag and drop이 작동하지 않는 경우가 있다는 이슈가 올라왔습니다.
2. 가로로 큰 레이아웃이 있어 preview에 가로 스크롤이 생길 때 에러가 발생하는 것을 확인 했습니다.
3. 3컬럼 구성을 fixed가 아닌 상위 컨테이너의 display: flex를 통해 구현하니 preview의 가로스크롤과 관계 없이 drag and drop이 정상 동작했습니다.
4. aside의 position: fixed, preview의 가로 스크롤 조건이 갖춰질 때 vue-smooth-dnd에 뭔가 간섭이 일어나는 듯 보입니다..
5. 정확히 무엇이 vue-smooth-dnd를 망가트리는지는 아직 찾지 못했습니다... 좀 더 살펴보겠습니다.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
스모크 테스트